### PR TITLE
[FIXED] Dependency ':qr_code_scanner_plus' requires core library desugaring to be enabled for :app.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ android {
 
     compileOptions {
         // Flag to enable support for the new language APIs
-        coreLibraryDesugaringEnabled true
+        // // // coreLibraryDesugaringEnabled true
         // Sets Java compatibility to Java 11
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
@@ -59,5 +59,5 @@ dependencies {
     implementation('com.journeyapps:zxing-android-embedded:4.3.0') { transitive = false }
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.zxing:core:3.5.2'
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
+    // // // coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated to Gradle version 8.9 for improved performance and features.
	- Introduced new properties for network timeout and distribution URL validation.
  
- **Bug Fixes**
	- Removed core library desugaring feature from the build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->