### PR TITLE
Fixing bugs with qr_code_scanner_plus in web

### DIFF
--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -58,7 +58,7 @@ class QRView extends StatefulWidget {
 }
 
 class _QRViewState extends State<QRView> {
-  late MethodChannel _channel;
+  MethodChannel? _channel;
   late LifecycleEventHandler _observer;
 
   @override
@@ -87,8 +87,9 @@ class _QRViewState extends State<QRView> {
   }
 
   Future<void> updateDimensions() async {
+    if (_channel == null) return;
     await QRViewController.updateDimensions(
-        widget.key as GlobalKey<State<StatefulWidget>>, _channel,
+        widget.key as GlobalKey<State<StatefulWidget>>, _channel!,
         overlay: widget.overlay);
   }
 
@@ -154,7 +155,7 @@ class _QRViewState extends State<QRView> {
 
     // Start scan after creation of the view
     final controller = QRViewController._(
-        _channel,
+        _channel!,
         widget.key as GlobalKey<State<StatefulWidget>>?,
         widget.onPermissionSet,
         widget.cameraFacing)

--- a/lib/src/web/flutter_qr_web.dart
+++ b/lib/src/web/flutter_qr_web.dart
@@ -5,6 +5,7 @@ import 'dart:core';
 // import 'dart:html' as html;
 import 'dart:js_interop';
 import 'dart:ui' as ui;
+import 'dart:ui_web' as ui_web;
 import 'package:web/web.dart' as web;
 
 import 'package:flutter/material.dart';
@@ -33,9 +34,6 @@ class WebQrView extends StatefulWidget {
 
   @override
   State<StatefulWidget> createState() => _WebQrViewState();
-
-  static web.HTMLDivElement vidDiv =
-      web.HTMLDivElement(); // need a global for the registerViewFactory
 
   static Future<bool> cameraAvailable() async {
     final sources =
@@ -79,13 +77,7 @@ class _WebQrViewState extends State<WebQrView> {
 
     facing = widget.cameraFacing ?? CameraFacing.front;
 
-    // TODO: old dart:html implementation was doing this which is not possible with web package
-    // WebQrView.vidDiv.children = [video];
-    WebQrView.vidDiv.children.add(video);
-
-    // ignore: UNDEFINED_PREFIXED_NAME
-    ui.platformViewRegistry
-        .registerViewFactory(viewID, (int id) => WebQrView.vidDiv);
+    ui_web.platformViewRegistry.registerViewFactory(viewID, (int id) => video);
     // giving JavaScipt some time to process the DOM changes
     Timer(const Duration(milliseconds: 500), () {
       start();

--- a/lib/src/web/jsqr.dart
+++ b/lib/src/web/jsqr.dart
@@ -4,7 +4,7 @@ library jsqr;
 import 'dart:js_interop';
 
 @JS('jsQR')
-external Code jsQR(JSTypedArray data, int? width, int? height);
+external Code? jsQR(JSTypedArray data, int? width, int? height);
 
 extension type Code._(JSObject _) implements JSObject {
   external String get data;


### PR DESCRIPTION
* MethodChannel should not be late as it can be used in updateDimensions if the web window is unfocused and focused again, this will call updateDimensions before the _onPlatformViewCreated method initializes _channel. Keeping it as null solves this problem.
* ui.platformViewRegistry is deprecated, ui_web.platformViewRegistry is the replacement
* This old code `WebQrView.vidDiv.children.add(video);` did not actually add the video element to the div so we didn't get any video output on web - so it had to be reworked or removed. I couldn't find a reason to adding a div, add the video to the div, and then adding the div to the platform view. I changed it to skip the div and just add the video element to the platform view directly - this seems to work nicely in the browsers I've tested.
* By removing the div, we can also remove to have it as a static variable in the widget class. I have no idea why this was a requirement for the platformview earlier but it does not seem to be a requirement anymore.

Please review these changes, merge if you approve and publish a new package version to pub.dev.

Thanks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved null safety for QR code scanning functionality across web and mobile platforms
	- Enhanced error handling in QR code detection mechanisms

- **Refactor**
	- Updated method signatures and type handling for more robust QR code scanning implementation
	- Streamlined web view registration for QR code scanning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->