### PR TITLE
Add stopCamera method and integrate it with widget lifecycle

### DIFF
--- a/lib/src/qr_code_scanner.dart
+++ b/lib/src/qr_code_scanner.dart
@@ -80,10 +80,21 @@ class _QRViewState extends State<QRView> {
     );
   }
 
+  Future<void> stopCamera() async {
+    if (_channel != null) {
+      try {
+        await _channel!.invokeMethod('stopCamera');
+      } on PlatformException catch (e) {
+        throw CameraException(e.code, e.message);
+      }
+    }
+  }
+
   @override
   void dispose() {
-    super.dispose();
     WidgetsBinding.instance.removeObserver(_observer);
+    stopCamera();
+    super.dispose();
   }
 
   Future<void> updateDimensions() async {


### PR DESCRIPTION
### This PR introduces the following changes:

1. stopCamera Method:

- Added a method stopCamera in the QRViewController to handle camera shutdown properly.
- Ensures the method is safely invoked when needed, using PlatformException handling.

2. Integrated stopCamera in Widget Lifecycle:

- Included stopCamera in the dispose method of the QRViewExample widget to ensure the camera stops gracefully when the widget is removed from the widget tree.
- Maintains proper resource cleanup and prevents potential memory leaks or dangling camera instances.

**Changes**:

`Future<void> stopCamera() async {
  if (_channel != null) {
    try {
      await _channel!.invokeMethod('stopCamera');
    } on PlatformException catch (e) {
      throw CameraException(e.code, e.message);
    }
  }
}`

**Updated**:
`@override
void dispose() {
  WidgetsBinding.instance.removeObserver(_observer);
  stopCamera();
  super.dispose();
}`

**Testing Instructions**

**- Manual Testing:**

1. Run the app and navigate to the QRView screen.
2. Close the QRView screen using the back button.
3. Check if the camera stops without errors in the logs.

**- Preliminary Tests:**

- Pending unit and widget tests for the stopCamera method (will be added in subsequent PRs).

**Checklist**

- Code written for stopCamera method.
- Integrated stopCamera in the dispose lifecycle method.
- Verified the app runs without errors after disposal.
- Tests written (to be included in a follow-up PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a method to stop the camera when the QR code scanner is no longer in use.

- **Bug Fixes**
	- Improved camera resource management to prevent potential resource leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->