### PR TITLE
Bugfix opening the wide camera instead of the main camera in the Android browser

### DIFF
--- a/lib/src/web/flutter_qr_web.dart
+++ b/lib/src/web/flutter_qr_web.dart
@@ -118,10 +118,23 @@ class _WebQrViewState extends State<WebQrView> {
     }
 
     try {
-      var constraints = UserMediaOptions(
-          video: VideoOptions(
-        facingMode: (facing == CameraFacing.front ? 'user' : 'environment'),
-      ));
+      List<dynamic> devices =
+          (await enumerateDevices().toDart) as List<dynamic>;
+      List<dynamic> backCameras = devices
+          .where((device) =>
+              device.kind == 'videoinput' &&
+              device.label.toLowerCase().contains('back'))
+          .toList();
+      UserMediaOptions constraints;
+      if (backCameras.isEmpty) {
+        constraints =
+            UserMediaOptions(video: VideoOptions(facingMode: "environment"));
+      } else {
+        constraints = UserMediaOptions(
+            video: VideoOptions(
+          deviceId: DeviceIdOptions(exact: "${backCameras.last.deviceId}"),
+        ));
+      }
       // dart style, not working properly:
       // var stream =
       //     await html.window.navigator.mediaDevices.getUserMedia(constraints);

--- a/lib/src/web/flutter_qr_web.dart
+++ b/lib/src/web/flutter_qr_web.dart
@@ -132,7 +132,7 @@ class _WebQrViewState extends State<WebQrView> {
       } else {
         constraints = UserMediaOptions(
             video: VideoOptions(
-          deviceId: DeviceIdOptions(exact: "${backCameras.last.deviceId}"),
+          deviceId: DeviceIdOptions(exact: "${backCameras[backCameras.length -1].deviceId}"),
         ));
       }
       // dart style, not working properly:

--- a/lib/src/web/media.dart
+++ b/lib/src/web/media.dart
@@ -10,6 +10,9 @@ import 'package:web/web.dart' as web;
 @JS('getUserMedia')
 external JSPromise<web.MediaStream> getUserMedia(UserMediaOptions constraints);
 
+@JS('enumerateDevices')
+external JSPromise<JSArray<web.MediaDeviceInfo>> enumerateDevices();
+
 @JS()
 extension type UserMediaOptions._(JSObject _) implements JSObject {
   external VideoOptions? get video;


### PR DESCRIPTION
This PR resolves an issue on Android devices with multiple cameras (e.g., Samsung S22 FE), where the browser would incorrectly open the wide camera instead of the main one. The fix ensures that the primary camera is selected by default when accessed through the browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced scanning functionality with improved camera selection that now prioritizes back cameras when available.
	- Expanded support for detecting available media devices to optimize camera usage.
- **Bug Fixes**
	- Refined error handling during camera access to ensure a smoother experience when issues arise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->