### PR TITLE
Fix iOS crash when popping QR scanner page during resume

### DIFF
--- a/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/NativeBarcodeScanner.swift
+++ b/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/NativeBarcodeScanner.swift
@@ -134,7 +134,9 @@ class NativeBarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
 
         let sess = session
         sessionQueue.async {
-            sess?.stopRunning()
+            if sess?.isRunning == true {
+                sess?.stopRunning()
+            }
         }
 
         DispatchQueue.main.async {

--- a/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/NativeBarcodeScanner.swift
+++ b/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/NativeBarcodeScanner.swift
@@ -137,6 +137,9 @@ class NativeBarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
             if sess?.isRunning == true {
                 sess?.stopRunning()
             }
+            DispatchQueue.main.async {
+                _ = sess
+            }
         }
 
         DispatchQueue.main.async {


### PR DESCRIPTION
## Summary

Fixes #20.

This addresses an intermittent iOS crash that can happen when a QR scanner page is reopened/resumed and then immediately popped during page navigation.

In the reported scenario:

1. Open a page containing `QRView`.
2. Push another page on top of it.
3. Pop/close pages twice.
4. Occasionally, `QRView.deinit` calls `stopScanning()`, which calls `AVCaptureSession.stopRunning()` and crashes.

The fix keeps the lifecycle change minimal by only calling `stopRunning()` when the capture session is actually running.

## Changes

- Guard `AVCaptureSession.stopRunning()` in iOS `stopScanning()` with `session.isRunning`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved barcode scanner shutdown to only stop active sessions, preventing unnecessary stop attempts and reducing race conditions.
  * Added a follow-up main-thread read after stopping to improve stability and reliability when ending scans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->