### PR TITLE
Migrate to built-in Kotlin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.2.0
+
+- Migrated to built-in Kotlin (AGP 9.0 compatibility). Removed `apply plugin: 'kotlin-android'` and the Kotlin Gradle Plugin classpath from `android/build.gradle`; same change in the example app's `example/android/app/build.gradle`. The `kotlin.compilerOptions { jvmTarget = JVM_17 }` block is now used in place of the legacy `kotlinOptions` block.
+- Bumped minimum Dart SDK to 3.12.0 and minimum Flutter version to 3.44.0, as required by the new built-in Kotlin DSL.
+- Example app: enabled `android.builtInKotlin=true` and `android.newDsl=true` in `example/android/gradle.properties`.
+
 ## 2.1.2
 
 - [iOS] Fix iOS crash when popping QR scanner page during resume (#21)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ group 'net.touchcapture.qr.flutterqrplus'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()
@@ -10,7 +9,6 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:8.1.0'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
 
@@ -22,7 +20,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     compileSdk 36
@@ -38,10 +35,6 @@ android {
         multiDexEnabled true
     }
 
-    kotlinOptions {
-        jvmTarget = '17'
-    }
-
     compileOptions {
         // Flag to enable support for the new language APIs
         // // // coreLibraryDesugaringEnabled true
@@ -55,9 +48,14 @@ android {
 }
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation('com.journeyapps:zxing-android-embedded:4.3.0') { transitive = false }
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.zxing:core:3.5.2'
     // // // coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -56,6 +55,8 @@ flutter {
     source '../..'
 }
 
-dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
 }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,6 +1,10 @@
-org.gradle.jvmargs=-Xmx1536M
+org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=true
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: qr_code_scanner_plus
 description: QR code scanner that can be embedded inside flutter. It uses zxing in Android and AVFoundation in iOS.
-version: 2.1.2
+version: 2.2.0
 homepage: https://vespr.xyz
 repository: https://github.com/vespr-wallet/qr_code_scanner_plus
 
 environment:
-  sdk: ">=3.5.0 <4.0.0"
-  flutter: ">=3.24.0"
+  sdk: ^3.12.0
+  flutter: '>=3.44.0'
 
 dependencies:
   # js: ^0.6.3


### PR DESCRIPTION
Migrates the plugin to use built-in Kotlin per the official Flutter
migration guide:
https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors

AGP 9.0 will remove support for plugins that apply the Kotlin Gradle
Plugin. This PR removes the legacy `apply plugin: "kotlin-android"`
line and the KGP classpath from `android/build.gradle`, and the same
from the example app's `example/android/app/build.gradle`.

The example app builds cleanly with `flutter build apk --debug` on
Flutter 3.44.1 with no KGP deprecation warnings.

Bumps the minimum Flutter version to 3.44.0 and Dart SDK to 3.12.0,
as required by the new `kotlin.compilerOptions` DSL.

Fixes the warning: "Your app uses the following plugins that apply
Kotlin Gradle Plugin (KGP)".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes - Version 2.2.0

* **Chores**
  * Released version 2.2.0.
  * Updated minimum Dart version requirement to 3.12.0 and Flutter version to 3.44.0.
  * Modernized the Android build system for improved compatibility with current development standards.

* **Documentation**
  * Updated CHANGELOG with version 2.2.0 release information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->