### PR TITLE
fix: resolve native iOS simulator crash by using localizedDescription

### DIFF
--- a/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/QRView.swift
+++ b/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/QRView.swift
@@ -202,7 +202,9 @@ public class QRView:NSObject,FlutterPlatformView {
                     }
                     try self.scanner?.startScanning()
                 } catch {
-                    let scanError = FlutterError(code: "unknown-error", message: "Unable to start scanning", details: error)
+                    // Convert Swift Error to String (localizedDescription) to avoid EXC_CRASH (SIGABRT)
+                    // since FlutterStandardMethodCodec only supports primitive types and cannot serialize raw Error/NSError objects.
+                    let scanError = FlutterError(code: "unknown-error", message: "Unable to start scanning", details: error.localizedDescription)
                     result(scanError)
                 }
             }


### PR DESCRIPTION
Closes #24

This PR resolves a native `EXC_CRASH (SIGABRT)` that triggers on environments without active camera hardware (such as the iOS Simulator) when `startScanning()` throws internally. 

The native crash was caused by the raw Swift `Error`/`NSError` object being passed directly into the `details` field of `FlutterError`. The `FlutterStandardMethodCodec` fails to serialize this complex type. By converting it to `error.localizedDescription`, we pass a codec-safe `String` instead, allowing the Dart side to catch the error cleanly as a `PlatformException`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during scan startup so failures now return a plain text error detail instead of a raw error object.
  * This helps prevent serialization issues and makes scan errors more reliably available in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->