### PR TITLE
fix(ios): bump minimum iOS deployment target to 13.0

### DIFF
--- a/ios/qr_code_scanner_plus.podspec
+++ b/ios/qr_code_scanner_plus.podspec
@@ -15,6 +15,6 @@ A new Flutter project.
   s.source           = { :path => '.' }
   s.source_files = 'qr_code_scanner_plus/Sources/qr_code_scanner_plus/**/*.swift'
   s.dependency 'Flutter'
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '13.0'
   s.swift_version = '5.0'
 end

--- a/ios/qr_code_scanner_plus/Package.swift
+++ b/ios/qr_code_scanner_plus/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "qr_code_scanner_plus",
     platforms: [
-        .iOS(.v12)
+        .iOS(.v13)
     ],
     products: [
         .library(name: "qr-code-scanner-plus", targets: ["qr_code_scanner_plus"])


### PR DESCRIPTION
FlutterFramework now requires a minimum iOS deployment target of 13.0, while the plugin was still configured for 12.0. This caused iOS builds to fail with:\n\n> The package product 'FlutterFramework' requires minimum platform version 13.0 for the iOS platform, but this target supports 12.0\n\nChanges:\n- Bump `s.ios.deployment_target` to 13.0 in `ios/qr_code_scanner_plus.podspec`\n- Bump platform to `.iOS(.v13)` in `ios/qr_code_scanner_plus/Package.swift`\n\nVerified by building the example app for iOS with `flutter build ios --no-codesign --debug`.\n\nFixes #23.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Raised the minimum supported iOS version to 13.0 for the QR code scanner package.
  * Updated package configuration to match the new iOS compatibility requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->