### PR TITLE
fix(ios): set AVCaptureVideoPreviewLayer videoOrientation for landscape apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Migrated to built-in Kotlin (AGP 9.0 compatibility). Removed `apply plugin: 'kotlin-android'` and the Kotlin Gradle Plugin classpath from `android/build.gradle`; same change in the example app's `example/android/app/build.gradle`. The `kotlin.compilerOptions { jvmTarget = JVM_17 }` block is now used in place of the legacy `kotlinOptions` block.
 - Bumped minimum Dart SDK to 3.12.0 and minimum Flutter version to 3.44.0, as required by the new built-in Kotlin DSL.
 - Example app: enabled `android.builtInKotlin=true` and `android.newDsl=true` in `example/android/gradle.properties`.
+- [iOS] Fix camera preview rotated 90° on landscape-only apps by setting `AVCaptureVideoPreviewLayer.connection.videoOrientation` (#19)
 
 ## 2.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 - Migrated to built-in Kotlin (AGP 9.0 compatibility). Removed `apply plugin: 'kotlin-android'` and the Kotlin Gradle Plugin classpath from `android/build.gradle`; same change in the example app's `example/android/app/build.gradle`. The `kotlin.compilerOptions { jvmTarget = JVM_17 }` block is now used in place of the legacy `kotlinOptions` block.
 - Bumped minimum Dart SDK to 3.12.0 and minimum Flutter version to 3.44.0, as required by the new built-in Kotlin DSL.
 - Example app: enabled `android.builtInKotlin=true` and `android.newDsl=true` in `example/android/gradle.properties`.
-- [iOS] Fix camera preview rotated 90° on landscape-only apps by setting `AVCaptureVideoPreviewLayer.connection.videoOrientation` (#19)
+- [iOS] Fix camera preview rotated 90° on landscape-only apps by setting `AVCaptureVideoPreviewLayer.connection.videoOrientation`, and keep the preview frame/orientation in sync on rotation via `layoutSubviews` (#19)
+- **[iOS] BREAKING:** Raised the minimum iOS deployment target from 12.0 to 13.0 (required for `UIWindowScene.interfaceOrientation`). Update your app's `Podfile`/`platform :ios` accordingly.
+- [iOS] Fix crash (`EXC_CRASH`/`SIGABRT`) when reporting a scan-start failure: pass `error.localizedDescription` instead of the raw `Error` to `FlutterError`, since `FlutterStandardMethodCodec` cannot serialize `Error`/`NSError`.
 
 ## 2.1.2
 

--- a/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/NativeBarcodeScanner.swift
+++ b/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/NativeBarcodeScanner.swift
@@ -46,16 +46,14 @@ class NativeBarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         guard let connection = previewLayer?.connection,
               connection.isVideoOrientationSupported else { return }
 
-        let orientation: UIInterfaceOrientation
-        if #available(iOS 13.0, *),
-           let scene = previewView.window?.windowScene
+        // Resolve the interface orientation from the window's scene, falling back
+        // to the first foreground-active scene when the view is not yet attached.
+        let scene = previewView.window?.windowScene
             ?? UIApplication.shared.connectedScenes
-                .compactMap({ $0 as? UIWindowScene })
-                .first(where: { $0.activationState == .foregroundActive }) {
-            orientation = scene.interfaceOrientation
-        } else {
-            orientation = UIApplication.shared.statusBarOrientation
-        }
+                .compactMap { $0 as? UIWindowScene }
+                .first { $0.activationState == .foregroundActive }
+        let orientation = scene?.interfaceOrientation ?? .portrait
+
         switch orientation {
         case .landscapeLeft:      connection.videoOrientation = .landscapeRight
         case .landscapeRight:     connection.videoOrientation = .landscapeLeft

--- a/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/NativeBarcodeScanner.swift
+++ b/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/NativeBarcodeScanner.swift
@@ -38,6 +38,32 @@ class NativeBarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         }
     }
 
+    // MARK: - Layout updates
+
+    /// Re-applies the current interface orientation to the preview layer. Call
+    /// this after the view's bounds or the device orientation changes.
+    func updateVideoOrientation() {
+        guard let connection = previewLayer?.connection,
+              connection.isVideoOrientationSupported else { return }
+
+        let orientation: UIInterfaceOrientation
+        if #available(iOS 13.0, *),
+           let scene = previewView.window?.windowScene
+            ?? UIApplication.shared.connectedScenes
+                .compactMap({ $0 as? UIWindowScene })
+                .first(where: { $0.activationState == .foregroundActive }) {
+            orientation = scene.interfaceOrientation
+        } else {
+            orientation = UIApplication.shared.statusBarOrientation
+        }
+        switch orientation {
+        case .landscapeLeft:      connection.videoOrientation = .landscapeRight
+        case .landscapeRight:     connection.videoOrientation = .landscapeLeft
+        case .portraitUpsideDown: connection.videoOrientation = .portraitUpsideDown
+        default:                  connection.videoOrientation = .portrait
+        }
+    }
+
     // MARK: - Private state
 
     private let previewView: UIView
@@ -108,6 +134,10 @@ class NativeBarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         let layer = AVCaptureVideoPreviewLayer(session: session)
         layer.videoGravity = .resizeAspectFill
         layer.frame = previewView.bounds
+
+        // Match the preview orientation to the current interface orientation so
+        // landscape-only apps do not see a 90° rotated feed.
+        updateVideoOrientation()
 
         self.session = session
         self.previewLayer = layer

--- a/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/NativeBarcodeScanner.swift
+++ b/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/NativeBarcodeScanner.swift
@@ -133,14 +133,15 @@ class NativeBarcodeScanner: NSObject, AVCaptureMetadataOutputObjectsDelegate {
         layer.videoGravity = .resizeAspectFill
         layer.frame = previewView.bounds
 
-        // Match the preview orientation to the current interface orientation so
-        // landscape-only apps do not see a 90° rotated feed.
-        updateVideoOrientation()
-
         self.session = session
         self.previewLayer = layer
         self.isSessionStarted = true
         self.isFrozen = false
+
+        // Match the preview orientation to the current interface orientation so
+        // landscape-only apps do not see a 90° rotated feed. Must run after
+        // `self.previewLayer` is assigned since it reads `previewLayer?.connection`.
+        updateVideoOrientation()
 
         DispatchQueue.main.async {
             self.previewView.layer.insertSublayer(layer, at: 0)

--- a/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/QRView.swift
+++ b/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/QRView.swift
@@ -99,6 +99,9 @@ public class QRView:NSObject,FlutterPlatformView {
             if let previewLayer = sc.getPreviewLayer() {
                 previewLayer.frame = self.previewView.bounds
             }
+            // Re-apply orientation in case the view rotated between start and
+            // the layout change (e.g. SizeChangedLayoutNotifier after rotation).
+            sc.updateVideoOrientation()
         } else {
             // Create new preview.
             scanner = NativeBarcodeScanner(previewView: previewView, cameraPosition: cameraFacing)

--- a/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/QRView.swift
+++ b/ios/qr_code_scanner_plus/Sources/qr_code_scanner_plus/QRView.swift
@@ -9,8 +9,21 @@ import Foundation
 import Flutter
 import AVFoundation
 
+/// A container view that notifies on every layout pass. This lets us keep the
+/// preview layer's frame and video orientation in sync with the actual view
+/// bounds, including after device/interface rotations, without relying on
+/// Flutter re-invoking `setDimensions`.
+class PreviewContainerView: UIView {
+    var onLayout: (() -> Void)?
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        onLayout?()
+    }
+}
+
 public class QRView:NSObject,FlutterPlatformView {
-    var previewView: UIView
+    var previewView: PreviewContainerView
     var scanner: NativeBarcodeScanner?
     var registrar: FlutterPluginRegistrar
     var channel: FlutterMethodChannel
@@ -39,9 +52,18 @@ public class QRView:NSObject,FlutterPlatformView {
 
     public init(withFrame frame: CGRect, withRegistrar registrar: FlutterPluginRegistrar, withId id: Int64, params: Dictionary<String, Any>){
         self.registrar = registrar
-        previewView = UIView(frame: frame)
+        previewView = PreviewContainerView(frame: frame)
         cameraFacing = CameraPosition(rawValue: UInt(Int(params["cameraFacing"] as! Double))) ?? .back
         channel = FlutterMethodChannel(name: "net.touchcapture.qr.flutterqrplus/qrview_\(id)", binaryMessenger: registrar.messenger())
+        super.init()
+
+        // Keep the preview layer's frame and orientation in sync with the view
+        // bounds on every layout pass (covers interface/device rotations).
+        previewView.onLayout = { [weak self] in
+            guard let self = self, let sc = self.scanner else { return }
+            sc.getPreviewLayer()?.frame = self.previewView.bounds
+            sc.updateVideoOrientation()
+        }
     }
 
     deinit {
@@ -99,8 +121,8 @@ public class QRView:NSObject,FlutterPlatformView {
             if let previewLayer = sc.getPreviewLayer() {
                 previewLayer.frame = self.previewView.bounds
             }
-            // Re-apply orientation in case the view rotated between start and
-            // the layout change (e.g. SizeChangedLayoutNotifier after rotation).
+            // Re-apply orientation here too; the view's layoutSubviews callback
+            // also handles this on rotation, but this covers explicit resizes.
             sc.updateVideoOrientation()
         } else {
             // Create new preview.


### PR DESCRIPTION
Fixes #19

Since 2.1.0 the iOS scanner uses the custom `NativeBarcodeScanner` instead of MTBBarcodeScanner. The new implementation never set the preview layer's `videoOrientation`, so it defaulted to `portrait`. On apps locked to landscape the camera feed appeared rotated 90° inside the QR view.

This change reads the current interface orientation from the first connected `UIWindowScene` (falling back to `UIApplication.statusBarOrientation` for older apps) and maps it to the corresponding `AVCaptureVideoOrientation`.

- Portrait-only apps are unaffected (default `portrait` remains correct).
- Does not affect Android or web.

Also bumps version to 2.1.3 and updates the changelog.